### PR TITLE
Add notifier interface

### DIFF
--- a/api/v1/event.go
+++ b/api/v1/event.go
@@ -1,0 +1,19 @@
+package v1
+
+// EventType is the type of event that occurred.
+type EventType string
+
+const (
+	EventTypeCreate     EventType = "create"
+	EventTypeUpdate     EventType = "update"
+	EventTypeDeleteSoft EventType = "deletesoft"
+	EventTypeDeleteHard EventType = "deletehard"
+)
+
+// DirectoryEvent is the event that is sent to the event stream.
+type DirectoryEvent struct {
+	DirectoryRequestMeta
+	Type      EventType `json:"type"`
+	Time      string    `json:"time"`
+	Directory Directory `json:"directory"`
+}

--- a/notifier/interface.go
+++ b/notifier/interface.go
@@ -1,0 +1,14 @@
+package notifier
+
+import (
+	"context"
+
+	apiv1 "github.com/infratographer/fertilesoil/api/v1"
+)
+
+type Notifier interface {
+	NotifyCreate(ctx context.Context, d *apiv1.Directory) error
+	NotifyUpdate(ctx context.Context, d *apiv1.Directory) error
+	NotifyDeleteSoft(ctx context.Context, d *apiv1.Directory) error
+	NotifyDeleteHard(ctx context.Context, d *apiv1.Directory) error
+}

--- a/notifier/noop/noop.go
+++ b/notifier/noop/noop.go
@@ -1,0 +1,33 @@
+package noop
+
+import (
+	"context"
+
+	apiv1 "github.com/infratographer/fertilesoil/api/v1"
+	"github.com/infratographer/fertilesoil/notifier"
+)
+
+func NewNotifier() notifier.Notifier {
+	return &noopNotifier{}
+}
+
+type noopNotifier struct{}
+
+// ensure noopNotifier implements notifier.Notifier.
+var _ notifier.Notifier = &noopNotifier{}
+
+func (n *noopNotifier) NotifyCreate(ctx context.Context, d *apiv1.Directory) error {
+	return nil
+}
+
+func (n *noopNotifier) NotifyUpdate(ctx context.Context, d *apiv1.Directory) error {
+	return nil
+}
+
+func (n *noopNotifier) NotifyDeleteSoft(ctx context.Context, d *apiv1.Directory) error {
+	return nil
+}
+
+func (n *noopNotifier) NotifyDeleteHard(ctx context.Context, d *apiv1.Directory) error {
+	return nil
+}

--- a/storage/notifier/notifier.go
+++ b/storage/notifier/notifier.go
@@ -1,0 +1,130 @@
+package notifier
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cenkalti/backoff/v4"
+
+	apiv1 "github.com/infratographer/fertilesoil/api/v1"
+	nif "github.com/infratographer/fertilesoil/notifier"
+	"github.com/infratographer/fertilesoil/storage"
+)
+
+var ErrNotifyFailed = errors.New("notification failed")
+
+type Option func(*notifierWithStorage)
+
+// StorageWithNotifier is a meta-storage driver that wraps a storage.DirectoryAdmin
+// and notifies a notifier.Notifier on every operation.
+// The notifier is called after the operation has been completed.
+func StorageWithNotifier(s storage.DirectoryAdmin, n nif.Notifier, opts ...Option) storage.DirectoryAdmin {
+	nws := &notifierWithStorage{
+		DirectoryAdmin: s,
+		notifier:       n,
+	}
+
+	for _, opt := range opts {
+		opt(nws)
+	}
+
+	return nws
+}
+
+// WithNotifyRetrier wraps the notifier with a retry mechanism.
+func WithNotifyRetrier() Option {
+	return func(n *notifierWithStorage) {
+		n.addWrapper(func(ctx context.Context, h handler) error {
+			return backoff.Retry(func() error {
+				return h(ctx)
+			}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
+		})
+	}
+}
+
+type notifierWithStorage struct {
+	storage.DirectoryAdmin
+	notifier      nif.Notifier
+	notifyWrapper wrapper
+}
+
+// ensure notifier implements storage.DirectoryAdmin.
+var _ storage.DirectoryAdmin = &notifierWithStorage{}
+
+// handles a notification.
+type handler func(context.Context) error
+
+// wraps a handler.
+type wrapper func(context.Context, handler) error
+
+func (n *notifierWithStorage) CreateDirectory(ctx context.Context, d *apiv1.Directory) (*apiv1.Directory, error) {
+	d, err := n.DirectoryAdmin.CreateDirectory(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	err = n.notifyWrapper(ctx, func(ctx context.Context) error {
+		if err := n.notifier.NotifyCreate(ctx, d); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return d, fmt.Errorf("%w: %v", ErrNotifyFailed, err)
+	}
+	return d, nil
+}
+
+func (n *notifierWithStorage) CreateRoot(ctx context.Context, d *apiv1.Directory) (*apiv1.Directory, error) {
+	d, err := n.DirectoryAdmin.CreateRoot(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	err = n.notifyWrapper(ctx, func(ctx context.Context) error {
+		if err := n.notifier.NotifyCreate(ctx, d); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return d, fmt.Errorf("%w: %v", ErrNotifyFailed, err)
+	}
+	return d, nil
+}
+
+// passthrough functions.
+func (n *notifierWithStorage) GetDirectory(ctx context.Context, id apiv1.DirectoryID) (*apiv1.Directory, error) {
+	return n.DirectoryAdmin.GetDirectory(ctx, id)
+}
+
+func (n *notifierWithStorage) GetParents(ctx context.Context, id apiv1.DirectoryID) ([]apiv1.DirectoryID, error) {
+	return n.DirectoryAdmin.GetParents(ctx, id)
+}
+
+func (n *notifierWithStorage) GetParentsUntilAncestor(ctx context.Context,
+	child apiv1.DirectoryID,
+	ancestor apiv1.DirectoryID,
+) ([]apiv1.DirectoryID, error) {
+	return n.DirectoryAdmin.GetParentsUntilAncestor(ctx, child, ancestor)
+}
+
+func (n *notifierWithStorage) GetChildren(ctx context.Context, id apiv1.DirectoryID) ([]apiv1.DirectoryID, error) {
+	return n.DirectoryAdmin.GetChildren(ctx, id)
+}
+
+func (n *notifierWithStorage) addWrapper(w wrapper) {
+	wrap := n.notifyWrapper
+	if wrap == nil {
+		n.notifyWrapper = w
+		return
+	}
+	n.notifyWrapper = func(ctx context.Context, h handler) error {
+		return wrap(ctx, func(ctx context.Context) error {
+			return w(ctx, h)
+		})
+	}
+}


### PR DESCRIPTION
This adds a notifier interface that can be used by a storage driver. The
intent is to dispatch CRUD events to different backends and through
different means. This could be a message-queue, a long polling session,
Server-Sent Events or anything else.

The main idea is to keep the storage and CRUD operations separated from
the eventing needs apps will have.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
