### PR TITLE
Reduce clutter in server logs

### DIFF
--- a/internal/httpsrv/treemanager/treemanager.go
+++ b/internal/httpsrv/treemanager/treemanager.go
@@ -96,7 +96,7 @@ func listRoots(s *common.Server) gin.HandlerFunc {
 func createRootDirectory(s *common.Server) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req v1.CreateDirectoryRequest
-		if err := c.BindJSON(&req); err != nil {
+		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
@@ -153,7 +153,7 @@ func createDirectory(s *common.Server) gin.HandlerFunc {
 		}
 
 		var req v1.CreateDirectoryRequest
-		if err := c.BindJSON(&req); err != nil {
+		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}


### PR DESCRIPTION
By using `ShouldBind` instead of `Bind` we reduce the stack traces that
the server was unnecessarily showing

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
