### PR TITLE
treemanager: Expose read-only mode and fast reads

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -84,7 +84,6 @@ github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-contrib/zap v0.1.0 h1:RMSFFJo34XZogV62OgOzvrlaMNmXrNxmJ3bFmMwl6Cc=
 github.com/gin-contrib/zap v0.1.0/go.mod h1:hvnZaPs478H1PGvRP8w89ZZbyJUiyip4ddiI/53WG3o=
-github.com/gin-gonic/gin v1.8.1 h1:4+fr/el88TOO3ewCmQr8cx/CtZ/umlIRIs5M4NTNjf8=
 github.com/gin-gonic/gin v1.8.1/go.mod h1:ji8BvRH1azfM+SYow9zQ6SZMvR8qOMZHmsCuWR9tTTk=
 github.com/gin-gonic/gin v1.8.2 h1:UzKToD9/PoFj/V4rvlKqTRKnQYyz8Sc1MJlv4JHPtvY=
 github.com/gin-gonic/gin v1.8.2/go.mod h1:qw5AYuDrzRTnhvusDsrov+fDIxp9Dleuu12h8nfB398=
@@ -305,8 +304,6 @@ github.com/nats-io/jwt/v2 v2.3.0 h1:z2mA1a7tIf5ShggOFlR1oBPgd6hGqcDYsISxZByUzdI=
 github.com/nats-io/jwt/v2 v2.3.0/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
 github.com/nats-io/nats-server/v2 v2.9.10 h1:LMC46Oi9E6BUx/xBsaCVZgofliAqKQzRPU6eKWkN8jE=
 github.com/nats-io/nats-server/v2 v2.9.10/go.mod h1:AB6hAnGZDlYfqb7CTAm66ZKMZy9DpfierY1/PbpvI2g=
-github.com/nats-io/nats.go v1.22.0 h1:3dxyVf+S449DbMriqQV27HgSbXklxT9SUKbDKIxhrV0=
-github.com/nats-io/nats.go v1.22.0/go.mod h1:tLqubohF7t4z3du1QDPYJIQQyhb4wl6DhjxEajSI7UA=
 github.com/nats-io/nats.go v1.22.1 h1:XzfqDspY0RNufzdrB8c4hFR+R3dahkxlpWe5+IWJzbE=
 github.com/nats-io/nats.go v1.22.1/go.mod h1:tLqubohF7t4z3du1QDPYJIQQyhb4wl6DhjxEajSI7UA=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=

--- a/internal/httpsrv/treemanager/config.go
+++ b/internal/httpsrv/treemanager/config.go
@@ -1,0 +1,100 @@
+package treemanager
+
+import (
+	"time"
+
+	"github.com/infratographer/fertilesoil/notifier"
+	"github.com/infratographer/fertilesoil/notifier/noop"
+	"github.com/infratographer/fertilesoil/storage/crdb/driver"
+)
+
+type treeManagerConfig struct {
+	listen          string
+	unix            string
+	debug           bool
+	readonly        bool
+	fastReads       bool
+	shutdownTimeout time.Duration
+	notif           notifier.Notifier
+}
+
+type Option func(*treeManagerConfig)
+
+// WithListen sets the listen address for the server.
+func WithListen(listen string) Option {
+	return func(c *treeManagerConfig) {
+		c.listen = listen
+	}
+}
+
+// WithUnix sets the unix socket for the server.
+// If set, the server will listen on the unix socket
+// instead of the listen address.
+func WithUnix(unix string) Option {
+	return func(c *treeManagerConfig) {
+		c.unix = unix
+	}
+}
+
+// WithDebug sets the debug flag for the server.
+func WithDebug(debug bool) Option {
+	return func(c *treeManagerConfig) {
+		c.debug = debug
+	}
+}
+
+// WithReadOnly sets the readonly flag for the server.
+// If true, the server will use the readonly flag when
+// reading from the database.
+func WithReadOnly(readonly bool) Option {
+	return func(c *treeManagerConfig) {
+		c.readonly = readonly
+	}
+}
+
+// WithFastReads sets the fastReads flag for the server.
+// If true, the server will use the fastReads flag when
+// reading from the database. This will cause the server
+// to read from the database without waiting for the
+// database to commit the transaction. This is useful
+// for read-heavy workloads, but can cause data to be
+// out of sync with the database.
+func WithFastReads(fastReads bool) Option {
+	return func(c *treeManagerConfig) {
+		c.fastReads = fastReads
+	}
+}
+
+// WithShutdownTimeout sets the shutdown timeout for the server.
+func WithShutdownTimeout(t time.Duration) Option {
+	return func(c *treeManagerConfig) {
+		c.shutdownTimeout = t
+	}
+}
+
+// WithNotifier sets the notifier for the server.
+func WithNotifier(n notifier.Notifier) Option {
+	return func(c *treeManagerConfig) {
+		if n == nil {
+			n = noop.NewNotifier()
+		}
+		c.notif = n
+	}
+}
+
+func (c *treeManagerConfig) apply(opts ...Option) {
+	for _, opt := range opts {
+		opt(c)
+	}
+}
+
+func (c *treeManagerConfig) withStorageDriverOptions() []driver.Options {
+	opts := []driver.Options{}
+	if c.readonly {
+		opts = append(opts, driver.WithReadOnly())
+	}
+	if c.fastReads {
+		opts = append(opts, driver.WithFastReads())
+	}
+	return opts
+}

--- a/internal/httpsrv/treemanager/defaults.go
+++ b/internal/httpsrv/treemanager/defaults.go
@@ -1,0 +1,25 @@
+package treemanager
+
+import (
+	"time"
+
+	"github.com/infratographer/fertilesoil/notifier/noop"
+)
+
+const (
+	// DefaultTreeManagerListen is the default listen address for the TreeManager.
+	DefaultTreeManagerListen = ":8080"
+	// DefaultTreeManagerUnix is the default unix socket for the TreeManager.
+	DefaultTreeManagerUnix = ""
+	// DefaultTreeManagerDebug is the default debug flag for the TreeManager.
+	DefaultTreeManagerDebug = false
+	// DefaultTreeManagerReadOnly is the default read-only flag for the TreeManager.
+	DefaultTreeManagerReadOnly = false
+	// DefaultTreeManagerFastReads is the default fast reads flag for the TreeManager.
+	DefaultTreeManagerFastReads = false
+	// DefaultTreeManagerShutdownTimeout is the default shutdown timeout for the TreeManager.
+	DefaultTreeManagerShutdownTimeout = 5 * time.Second
+)
+
+// DefaultTreeManagerNotifier is the default notifier for the TreeManager.
+var DefaultTreeManagerNotifier = noop.NewNotifier()

--- a/tests/integration/client_test.go
+++ b/tests/integration/client_test.go
@@ -348,7 +348,14 @@ func TestServerWithBadDB(t *testing.T) {
 	dbconn, err := sql.Open("postgres", baseDBURL.String())
 	assert.NoError(t, err, "error creating db connection")
 
-	srv := treemanager.NewServer(tl, srvhost, dbconn, debug, defaultShutdownTime, skt, nil)
+	srv := treemanager.NewServer(
+		tl,
+		dbconn,
+		treemanager.WithListen(srvhost),
+		treemanager.WithDebug(debug),
+		treemanager.WithShutdownTimeout(defaultShutdownTime),
+		treemanager.WithUnix(skt),
+	)
 
 	defer func() {
 		err := srv.Shutdown()

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -81,7 +81,15 @@ func newTestServerWithNotifier(t *testing.T, skt string, notif notifier.Notifier
 
 	gooseDBMutex.Unlock()
 
-	tm := treemanager.NewServer(tl, srvhost, dbconn, debug, defaultShutdownTime, skt, notif)
+	tm := treemanager.NewServer(
+		tl,
+		dbconn,
+		treemanager.WithListen(srvhost),
+		treemanager.WithDebug(debug),
+		treemanager.WithShutdownTimeout(defaultShutdownTime),
+		treemanager.WithUnix(skt),
+		treemanager.WithNotifier(notif),
+	)
 
 	return tm
 }


### PR DESCRIPTION
This exposes the driver's read-only mode and fast reads options to the
tree manager server. When used, this will run the tree manager in a mode
that disallows any write operations. If fast reads are used, it will
attempt to use the fast read or inconsistent mode. In CockroachDB this
translates to using follower reads to allow an instance to fetch data
from a follower instead of relying on the leader.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
