### PR TITLE
Switch to chainguard wolfi images and add CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,37 @@ jobs:
           file: ./coverage.out
           flags: unittests
           name: codecov-umbrella
+
+  build-image:
+    name: build-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v3
+
+      - name: Build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./images/treeman/Dockerfile
+          push: false
+          load: true
+          tags: ghcr.io/infratographer/fertilesoil/treeman:latest
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ghcr.io/infratographer/fertilesoil/treeman:latest
+          security-checks: 'vuln,config,secret'
+          ignore-unfixed: true
+          severity: 'HIGH,CRITICAL'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+      - name: Inspect action SARIF report
+        run: cat 'trivy-results.sarif'

--- a/images/treeman/Dockerfile
+++ b/images/treeman/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.19 as build-env
+FROM cgr.dev/chainguard/go:1.19 as build-env
 
 WORKDIR /go/src/fertilesoil
 
@@ -10,7 +10,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 go build -o /go/bin/treeman main.go 
 
-FROM gcr.io/distroless/static:nonroot
+FROM cgr.dev/chainguard/static:latest
 
 # `nonroot` coming from distroless
 USER 65532:65532


### PR DESCRIPTION
This changes to using the changuard wolfi imges as a base for the
container. It also adds a CI job that does both a build and a security
scan.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
