### PR TITLE
Enable running CI on command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
This enables us to click a button manually to run CI tests if needed.
Nothing changes except that we enable this functionality.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
