### PR TITLE
have renovate go mod tidy on updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,8 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true
     }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
Renovate doesn't run go mod tidy after updating a dependency leaving old entries in the go.sum file.

This change ensures renovate cleans up the go.sum file with an update.