### PR TITLE
app: Make HTTP client optional

### DIFF
--- a/app/v1/controller.go
+++ b/app/v1/controller.go
@@ -32,7 +32,9 @@ type Controller interface {
 type ControllerBuilder func(baseDir apiv1.DirectoryID, opts ...Option) (Controller, error)
 
 // NewController is the default implementation of ControllerBuilder.
-var NewController ControllerBuilder = newController
+var NewController ControllerBuilder = func(baseDir apiv1.DirectoryID, opts ...Option) (Controller, error) {
+	return newController(baseDir, opts...)
+}
 
 // Option is a function that configures the controller.
 type Option func(*controller)
@@ -58,3 +60,17 @@ var WithWatcher = withWatcher
 // interval.
 // The default full reconcile interval is between 5 minutes and 15 minutes.
 var WithFullReconcileInterval = withFullReconcileInterval
+
+// Seeder is an interface which allows to reconcile the
+// full subtree of a directory structure.
+// This is useful when the controller is started and needs to
+// initialize the store with the current state of the directory structure.
+// An HTTP client is required to perform the reconciliation.
+type Seeder interface {
+	InitializeDirectories(ctx context.Context) error
+}
+
+// NewSeeder is a builder function that creates a new
+// FullSubtreeReconciler. It's useful for doing a full reconciler and persistence
+// of the directory tree in an application without having to start the controller.
+var NewSeeder = newSeeder

--- a/app/v1/fullsubtree_reconciler.go
+++ b/app/v1/fullsubtree_reconciler.go
@@ -1,0 +1,77 @@
+package v1
+
+import (
+	"context"
+
+	apiv1 "github.com/infratographer/fertilesoil/api/v1"
+	clientv1 "github.com/infratographer/fertilesoil/client/v1"
+)
+
+func newSeeder(
+	baseDir apiv1.DirectoryID,
+	cli clientv1.ReadOnlyClient,
+	store AppStorage,
+) (Seeder, error) {
+	return newController(baseDir,
+		WithClient(cli),
+		withStorage(store),
+		WithReconciler(&NoopReconciler{}))
+}
+
+// InitializeDirectories initializes the directories in the store.
+// It checks if the base directory is up-to-date on the store.
+// If it is not, it is persisted.
+func (c *controller) InitializeDirectories(ctx context.Context) error {
+	// not having the client is not an error, it just means that the controller
+	// solely relies on events to update the store.
+	if c.c == nil {
+		return nil
+	}
+
+	err := c.persistIfUpToDate(ctx, c.baseDir)
+	if err != nil {
+		return err
+	}
+
+	// check if all subdirs are tracked and up-to-date, else, persist them.
+	subdirs, err := c.c.GetChildren(ctx, c.baseDir)
+	if err != nil {
+		return err
+	}
+
+	for _, subdir := range subdirs.Directories {
+		err := c.persistIfUpToDate(ctx, subdir)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// persistIfUpToDate checks if the directory is up-to-date on the store.
+// If it is not, it is persisted.
+func (c *controller) persistIfUpToDate(ctx context.Context, dir apiv1.DirectoryID) error {
+	// not having the client is not an error, it just means that the controller
+	// solely relies on events to update the store.
+	if c.c == nil {
+		return nil
+	}
+
+	fd, err := c.c.GetDirectory(ctx, dir)
+	if err != nil {
+		return err
+	}
+
+	d := &fd.Directory
+	upToDate, err := c.store.IsDirectoryInfoUpdated(ctx, d)
+	if err != nil {
+		return err
+	}
+
+	if upToDate {
+		return nil
+	}
+
+	return c.persistDirectory(ctx, d)
+}

--- a/app/v1/noop_reconciler.go
+++ b/app/v1/noop_reconciler.go
@@ -1,0 +1,17 @@
+package v1
+
+import (
+	"context"
+
+	apiv1 "github.com/infratographer/fertilesoil/api/v1"
+)
+
+// NoopReconciler is a Reconciler that does nothing.
+// This is useful in cases where we just want to persist the directory tree
+// without doing any reconciliation.
+type NoopReconciler struct{}
+
+//nolint:gocritic // we want to keep the signature of the Reconciler interface
+func (r *NoopReconciler) Reconcile(ctx context.Context, de apiv1.DirectoryEvent) error {
+	return nil
+}

--- a/tests/integration/app_test.go
+++ b/tests/integration/app_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	apiv1 "github.com/infratographer/fertilesoil/api/v1"
+	appv1 "github.com/infratographer/fertilesoil/app/v1"
 	clientv1nats "github.com/infratographer/fertilesoil/client/v1/nats"
 	"github.com/infratographer/fertilesoil/notifier/nats"
 	natsutils "github.com/infratographer/fertilesoil/notifier/nats/utils"
@@ -135,6 +136,130 @@ func TestAppReconcileAndWatch(t *testing.T) {
 	// we should have 2 reconcile calls
 	// as the directories are up-to-date
 	assert.Equal(t, apptester.getReconcileCalls(), uint32(3), "expected 3 reconcile calls")
+
+	evts = apptester.popEvents()
+
+	// We should have done one reconcile for the new directory
+	assert.Len(t, evts, 1, "expected 1 event")
+
+	// We should have created the directory
+	assert.Equal(t, apiv1.EventTypeCreate, evts[0].Type, "expected created event")
+
+	cancel()
+}
+
+// This scenario tests the following:
+//  1. Create a new application
+//  2. Create a new directory
+//  3. The application should be notified of the new directory
+//  4. The application should be notified of new subdirectories
+func TestAppWatchWithoutClient(t *testing.T) {
+	t.Parallel()
+
+	// initialize socket to communicate with the tree manager
+	skt := testutils.NewUnixsocketPath(t)
+
+	// initialize NATS server for notifications
+	natss, natserr := natsutils.StartNatsServer()
+	assert.NoError(t, natserr, "error starting nats server")
+
+	defer natss.Shutdown()
+
+	conn, err := natsgo.Connect(natss.ClientURL())
+	assert.NoError(t, err, "connecting to nats server")
+
+	clientconn, err := natsgo.Connect(natss.ClientURL())
+	assert.NoError(t, err, "connecting to nats server")
+
+	natsutils.WaitConnected(t, conn)
+	natsutils.WaitConnected(t, clientconn)
+
+	subject := t.Name()
+
+	// build notifier
+	ntf, err := nats.NewNotifier(conn, subject)
+	assert.NoError(t, err, "creating nats notifier")
+
+	// Build tree manager server
+	srv := newTestServerWithNotifier(t, skt, ntf)
+	defer func() {
+		err := srv.Shutdown()
+		assert.NoError(t, err, "error shutting down server")
+	}()
+
+	go testutils.RunTestServer(t, srv)
+
+	cli := testutils.NewTestClient(t, skt, baseServerAddress, nil)
+
+	testutils.WaitForServer(t, cli)
+
+	// initialize root. An app needs a root to be initialized
+	rd, err := cli.CreateRoot(context.Background(), &apiv1.CreateDirectoryRequest{
+		Version: apiv1.APIVersion,
+		Name:    "root",
+	})
+	assert.NoError(t, err, "error creating root")
+
+	// Set up test application
+	appstore := setupAppStorage(t)
+
+	watcher, err := clientv1nats.NewSubscriber(clientconn, subject)
+	assert.NoError(t, err, "error creating nats subscriber")
+
+	fullrec, err := appv1.NewSeeder(rd.Directory.Id, cli, appstore)
+	assert.NoError(t, err, "error creating full subtree reconciler")
+
+	// Trigger a full reconcile
+	err = fullrec.InitializeDirectories(context.Background())
+	assert.NoError(t, err, "error initializing directories")
+
+	// We don't pass a client to the application controller
+	appctrl, apptester := setupTestApp(t, rd.Directory.Id, nil, watcher, appstore)
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+
+	// Run application controller. This will initialize the application and
+	// start watching for changes
+	go func() {
+		runerr := appctrl.Run(cancelCtx)
+		assert.ErrorIs(t, runerr, context.Canceled, "expected context canceled error")
+	}()
+
+	// At this point we don't have any events yet. Let's trigger some!
+
+	// Create a directory
+	_, err = cli.CreateDirectory(context.Background(), &apiv1.CreateDirectoryRequest{
+		Version: apiv1.APIVersion,
+		Name:    "test",
+	}, rd.Directory.Id)
+	assert.NoError(t, err, "error creating directory")
+
+	apptester.waitForReconcile()
+
+	evts := apptester.popEvents()
+
+	// We should have done one reconcile for the new directory
+	assert.Len(t, evts, 1, "expected 1 event")
+
+	// We should have created the directory
+	assert.Equal(t, apiv1.EventTypeCreate, evts[0].Type, "expected created event")
+
+	// We should only have two reconcile calls
+	assert.Equal(t, apptester.getReconcileCalls(), uint32(1), "expected 1 reconcile calls")
+
+	// Create a subdirectory
+	_, err = cli.CreateDirectory(context.Background(), &apiv1.CreateDirectoryRequest{
+		Version: apiv1.APIVersion,
+		Name:    "subtest",
+	}, rd.Directory.Id)
+	assert.NoError(t, err, "error creating directory")
+
+	// wait for a full reconcile
+	apptester.waitForReconcile()
+
+	// we should have 2 reconcile calls
+	// as the directories are up-to-date
+	assert.Equal(t, apptester.getReconcileCalls(), uint32(2), "expected 2 reconcile calls")
 
 	evts = apptester.popEvents()
 


### PR DESCRIPTION
This makes the HTTP client an optional parameter for the application
Reconciler.

In order to ensure that the tree structure in the application doesn't
drift, this provides a relevant interface (`Seeder`) to allow service
authors to trigger full reconciliation if needed without having to rely
on a built-in client for their application.

Closes #43