### PR TITLE
Release multi-arch builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,5 @@ jobs:
       tag: ${GITHUB_REF_NAME}
       registry_org: ${{ github.repository }}
       dockerfile_path: images/treeman/Dockerfile
+      platforms: linux/amd64,linux/arm64
+


### PR DESCRIPTION
This releases both ARM and x86 images for treeman.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
