### PR TITLE
Fix release: Use github context instead of env variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
     with:
       name: treeman
-      tag: ${GITHUB_REF_NAME}
+      tag: ${{ github.ref_name }}
       registry_org: ${{ github.repository }}
       dockerfile_path: images/treeman/Dockerfile
       platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
The variable is not evaluated during the workflow call evaluation, we
should use the `github` context instead.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
