### PR TITLE
Create nats stream if it doesn't exist.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 
 require (
 	github.com/XSAM/otelsql v0.17.1 // indirect
+	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.8.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/notifier/nats/nats.go
+++ b/notifier/nats/nats.go
@@ -4,53 +4,117 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
-	natsgo "github.com/nats-io/nats.go"
+	nats "github.com/nats-io/nats.go"
+	"go.uber.org/zap"
 
 	apiv1 "github.com/infratographer/fertilesoil/api/v1"
-	"github.com/infratographer/fertilesoil/notifier"
 )
 
 // NewNotifier creates a new NATS notifier using JetStream.
 // The subject is the NATS subject to publish events to.
-func NewNotifier(js natsgo.JetStreamContext, subject string) notifier.Notifier {
-	return &natsnotifier{
-		js:      js,
-		subject: subject,
+func NewNotifier(js nats.JetStreamContext, subjectPrefix string, options ...Option) *Notifier {
+	n := &Notifier{
+		logger:        zap.NewNop(),
+		js:            js,
+		subjectPrefix: subjectPrefix,
+	}
+
+	for _, opt := range options {
+		opt(n)
+	}
+
+	return n
+}
+
+// Option is a functional configuration option for governor eventing.
+type Option func(c *Notifier)
+
+// WithLogger sets the logger.
+func WithLogger(l *zap.Logger) Option {
+	return func(n *Notifier) {
+		n.logger = l
 	}
 }
 
-type natsnotifier struct {
-	js      natsgo.JetStreamContext
-	subject string
+// WithPublishOptions sets the nats publish options.
+func WithPublishOptions(options ...nats.PubOpt) Option {
+	return func(n *Notifier) {
+		n.publishOptions = options
+	}
 }
 
-func (n *natsnotifier) NotifyCreate(ctx context.Context, d *apiv1.Directory) error {
+// Notifier implements NATS notification handling.
+type Notifier struct {
+	logger         *zap.Logger
+	js             nats.JetStreamContext
+	subjectPrefix  string
+	publishOptions []nats.PubOpt
+}
+
+// AddStream checks if a stream exists and attempts to create it if it doesn't.
+// Currently we don't check that the stream is configured identically to the desired configuration.
+func (n *Notifier) AddStream(stream *nats.StreamConfig) (*nats.StreamInfo, error) {
+	info, err := n.js.StreamInfo(stream.Name)
+	if err == nil {
+		n.logger.Debug("got info for stream, assuming stream exists", zap.Any("nats.stream.info", info.Config))
+
+		return info, nil
+	} else if !errors.Is(err, nats.ErrStreamNotFound) {
+		n.logger.Error("failed to get stream info", zap.Error(err))
+
+		return nil, err
+	}
+
+	n.logger.Debug("nats stream not found, attempting to create it", zap.String("nats.stream.name", stream.Name))
+
+	// Ensure we're capturing each action.
+	stream.Subjects = append(stream.Subjects, n.subjectPrefix+".>")
+
+	return n.js.AddStream(stream)
+}
+
+// NotifyCreate publishes a create event for the provided directory.
+func (n *Notifier) NotifyCreate(ctx context.Context, d *apiv1.Directory) error {
 	return n.publish(getEvent(apiv1.EventTypeCreate, d))
 }
 
-func (n *natsnotifier) NotifyUpdate(ctx context.Context, d *apiv1.Directory) error {
+// NotifyUpdate publishes an update event for the provided directory.
+func (n *Notifier) NotifyUpdate(ctx context.Context, d *apiv1.Directory) error {
 	return n.publish(getEvent(apiv1.EventTypeUpdate, d))
 }
 
-func (n *natsnotifier) NotifyDelete(ctx context.Context, d *apiv1.Directory) error {
+// NotifyDelete publishes a delete event for the provided directory.
+func (n *Notifier) NotifyDelete(ctx context.Context, d *apiv1.Directory) error {
 	return n.publish(getEvent(apiv1.EventTypeDelete, d))
 }
 
-func (n *natsnotifier) NotifyDeleteHard(ctx context.Context, d *apiv1.Directory) error {
+// NotifyDeleteHard publishes a hard delete event for the provided directory.
+func (n *Notifier) NotifyDeleteHard(ctx context.Context, d *apiv1.Directory) error {
 	return n.publish(getEvent(apiv1.EventTypeDeleteHard, d))
 }
 
-func (n *natsnotifier) publish(evt *apiv1.DirectoryEvent) error {
+func (n *Notifier) publish(evt *apiv1.DirectoryEvent) error {
 	var buff bytes.Buffer
 
 	if err := json.NewEncoder(&buff).Encode(evt); err != nil {
 		return fmt.Errorf("failed encoding event: %w", err)
 	}
 
-	if _, err := n.js.Publish(n.subject, buff.Bytes()); err != nil {
+	subject := n.subjectPrefix + "." + string(evt.Type)
+
+	n.logger.Debug("Sending event", zap.String("nats.publish.subject", subject), zap.Any("nats.publish.body", evt))
+
+	if _, err := n.js.Publish(subject, buff.Bytes(), n.publishOptions...); err != nil {
+		n.logger.Debug("Failed to send event",
+			zap.String("nats.publish.subject", subject),
+			zap.Any("nats.publish.body", evt),
+			zap.Error(err),
+		)
+
 		return fmt.Errorf("failed to publish event to: %w", err)
 	}
 

--- a/notifier/nats/nats_test.go
+++ b/notifier/nats/nats_test.go
@@ -10,10 +10,15 @@ import (
 	natssrv "github.com/nats-io/nats-server/v2/server"
 	natsgo "github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
 
 	apiv1 "github.com/infratographer/fertilesoil/api/v1"
 	"github.com/infratographer/fertilesoil/notifier/nats"
 	natsutils "github.com/infratographer/fertilesoil/notifier/nats/utils"
+)
+
+const (
+	natsMsgSubTimeout = 2 * time.Second
 )
 
 var natss *natssrv.Server
@@ -31,9 +36,8 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
+//nolint:paralleltest // Subtests must be sequential.
 func TestBasicNotifications(t *testing.T) {
-	t.Parallel()
-
 	subject := t.Name()
 
 	conn, err := natsgo.Connect(natss.ClientURL())
@@ -42,30 +46,27 @@ func TestBasicNotifications(t *testing.T) {
 	js, err := conn.JetStream()
 	assert.NoError(t, err, "creating JetStream connection")
 
-	_, err = js.AddStream(&natsgo.StreamConfig{
-		Name:     subject,
-		Subjects: []string{subject},
-		Storage:  natsgo.MemoryStorage,
-	})
-	assert.NoError(t, err, "creating JetStream stream")
-
 	clientconn, err := natsgo.Connect(natss.ClientURL())
 	assert.NoError(t, err, "connecting to nats server")
 
 	natsutils.WaitConnected(t, conn)
 	natsutils.WaitConnected(t, clientconn)
 
-	ntf := nats.NewNotifier(js, subject)
+	ntf := nats.NewNotifier(js, subject, nats.WithLogger(zaptest.NewLogger(t)))
 	assert.NoError(t, err, "creating nats notifier")
 
+	_, err = ntf.AddStream(&natsgo.StreamConfig{
+		Name:    subject,
+		Storage: natsgo.MemoryStorage,
+	})
+	assert.NoError(t, err, "creating JetStream stream")
+
 	msgChan := make(chan *natsgo.Msg, 10)
-	_, err = clientconn.Subscribe(subject, func(m *natsgo.Msg) {
+	_, err = clientconn.Subscribe(subject+".*", func(m *natsgo.Msg) {
 		t.Logf("Received message: %s", string(m.Data))
 		msgChan <- m
 	})
 	assert.NoError(t, err, "creating NATS subscription")
-
-	// Send create
 	now := time.Now().UTC()
 	dir := &apiv1.Directory{
 		Id:   apiv1.DirectoryID(uuid.New()),
@@ -78,73 +79,102 @@ func TestBasicNotifications(t *testing.T) {
 		Parent:    nil,
 	}
 
-	err = ntf.NotifyCreate(context.Background(), dir)
-	assert.NoError(t, err, "notifying create")
+	t.Run("notify create", func(t *testing.T) {
+		err = ntf.NotifyCreate(context.Background(), dir)
+		assert.NoError(t, err, "notifying create")
 
-	// Receive create
-	msg := <-msgChan
+		var msg *natsgo.Msg
 
-	unmarshalled := &apiv1.DirectoryEvent{}
-	err = json.Unmarshal(msg.Data, unmarshalled)
+		// Receive create
+		select {
+		case msg = <-msgChan:
+		case <-time.After(natsMsgSubTimeout):
+			t.Error("failed to receive nats message")
+		}
 
-	assert.NoError(t, err, "unmarshalling nats message")
-	assert.Equal(t, apiv1.EventTypeCreate, unmarshalled.Type)
-	assert.Equal(t, dir.Id, unmarshalled.Directory.Id)
-	assert.Equal(t, dir.Name, unmarshalled.Directory.Name)
-	assert.Equal(t, dir.Metadata, unmarshalled.Directory.Metadata)
-	assert.Equal(t, dir.CreatedAt, unmarshalled.Directory.CreatedAt)
+		unmarshalled := &apiv1.DirectoryEvent{}
+		err = json.Unmarshal(msg.Data, unmarshalled)
 
-	// Send update
-	now = time.Now().UTC()
-	dir.UpdatedAt = time.Now().UTC()
+		assert.NoError(t, err, "unmarshalling nats message")
+		assert.Equal(t, apiv1.EventTypeCreate, unmarshalled.Type)
+		assert.Equal(t, dir.Id, unmarshalled.Directory.Id)
+		assert.Equal(t, dir.Name, unmarshalled.Directory.Name)
+		assert.Equal(t, dir.Metadata, unmarshalled.Directory.Metadata)
+		assert.Equal(t, dir.CreatedAt, unmarshalled.Directory.CreatedAt)
+	})
 
-	err = ntf.NotifyUpdate(context.Background(), dir)
-	assert.NoError(t, err, "notifying update")
+	t.Run("send update", func(t *testing.T) {
+		now = time.Now().UTC()
+		dir.UpdatedAt = time.Now().UTC()
 
-	// Receive update
-	msg = <-msgChan
+		err = ntf.NotifyUpdate(context.Background(), dir)
+		assert.NoError(t, err, "notifying update")
 
-	unmarshalled = &apiv1.DirectoryEvent{}
-	err = json.Unmarshal(msg.Data, unmarshalled)
+		var msg *natsgo.Msg
 
-	assert.NoError(t, err, "unmarshalling nats message")
-	assert.Equal(t, apiv1.EventTypeUpdate, unmarshalled.Type)
-	assert.Equal(t, dir.Id, unmarshalled.Directory.Id)
-	assert.Equal(t, dir.Name, unmarshalled.Directory.Name)
-	assert.Equal(t, dir.Metadata, unmarshalled.Directory.Metadata)
-	assert.Equal(t, dir.UpdatedAt, unmarshalled.Directory.UpdatedAt)
+		// Receive update
+		select {
+		case msg = <-msgChan:
+		case <-time.After(natsMsgSubTimeout):
+			t.Error("failed to receive nats message")
+		}
 
-	// Send delete
-	dir.DeletedAt = &now
+		unmarshalled := &apiv1.DirectoryEvent{}
+		err = json.Unmarshal(msg.Data, unmarshalled)
 
-	err = ntf.NotifyDelete(context.Background(), dir)
-	assert.NoError(t, err, "notifying delete")
+		assert.NoError(t, err, "unmarshalling nats message")
+		assert.Equal(t, apiv1.EventTypeUpdate, unmarshalled.Type)
+		assert.Equal(t, dir.Id, unmarshalled.Directory.Id)
+		assert.Equal(t, dir.Name, unmarshalled.Directory.Name)
+		assert.Equal(t, dir.Metadata, unmarshalled.Directory.Metadata)
+		assert.Equal(t, dir.UpdatedAt, unmarshalled.Directory.UpdatedAt)
+	})
 
-	// Receive delete
-	msg = <-msgChan
+	t.Run("send delete", func(t *testing.T) {
+		dir.DeletedAt = &now
 
-	unmarshalled = &apiv1.DirectoryEvent{}
-	err = json.Unmarshal(msg.Data, unmarshalled)
+		err = ntf.NotifyDelete(context.Background(), dir)
+		assert.NoError(t, err, "notifying delete")
 
-	assert.NoError(t, err, "unmarshalling nats message")
-	assert.Equal(t, apiv1.EventTypeDelete, unmarshalled.Type)
-	assert.Equal(t, dir.Id, unmarshalled.Directory.Id)
-	assert.Equal(t, dir.Name, unmarshalled.Directory.Name)
-	assert.Equal(t, dir.Metadata, unmarshalled.Directory.Metadata)
-	assert.Equal(t, dir.DeletedAt, unmarshalled.Directory.DeletedAt)
+		var msg *natsgo.Msg
 
-	// Send delete hard
-	err = ntf.NotifyDeleteHard(context.Background(), dir)
-	assert.NoError(t, err, "notifying delete hard")
+		// Receive delete
+		select {
+		case msg = <-msgChan:
+		case <-time.After(natsMsgSubTimeout):
+			t.Error("failed to receive nats message")
+		}
 
-	// Receive delete hard
-	msg = <-msgChan
+		unmarshalled := &apiv1.DirectoryEvent{}
+		err = json.Unmarshal(msg.Data, unmarshalled)
 
-	unmarshalled = &apiv1.DirectoryEvent{}
-	err = json.Unmarshal(msg.Data, unmarshalled)
+		assert.NoError(t, err, "unmarshalling nats message")
+		assert.Equal(t, apiv1.EventTypeDelete, unmarshalled.Type)
+		assert.Equal(t, dir.Id, unmarshalled.Directory.Id)
+		assert.Equal(t, dir.Name, unmarshalled.Directory.Name)
+		assert.Equal(t, dir.Metadata, unmarshalled.Directory.Metadata)
+		assert.Equal(t, dir.DeletedAt, unmarshalled.Directory.DeletedAt)
+	})
 
-	assert.NoError(t, err, "unmarshalling nats message")
-	assert.Equal(t, apiv1.EventTypeDeleteHard, unmarshalled.Type)
+	t.Run("send hard delete", func(t *testing.T) {
+		err = ntf.NotifyDeleteHard(context.Background(), dir)
+		assert.NoError(t, err, "notifying delete hard")
+
+		var msg *natsgo.Msg
+
+		// Receive delete hard
+		select {
+		case msg = <-msgChan:
+		case <-time.After(natsMsgSubTimeout):
+			t.Error("failed to receive nats message")
+		}
+
+		unmarshalled := &apiv1.DirectoryEvent{}
+		err = json.Unmarshal(msg.Data, unmarshalled)
+
+		assert.NoError(t, err, "unmarshalling nats message")
+		assert.Equal(t, apiv1.EventTypeDeleteHard, unmarshalled.Type)
+	})
 }
 
 func TestNotifyCreateFailsOnBadConnection(t *testing.T) {
@@ -158,16 +188,15 @@ func TestNotifyCreateFailsOnBadConnection(t *testing.T) {
 	js, err := conn.JetStream()
 	assert.NoError(t, err, "creating JetStream connection")
 
-	_, err = js.AddStream(&natsgo.StreamConfig{
-		Name:     subject,
-		Subjects: []string{subject},
-		Storage:  natsgo.MemoryStorage,
-	})
-	assert.NoError(t, err, "creating JetStream stream")
-
 	natsutils.WaitConnected(t, conn)
 
-	ntf := nats.NewNotifier(js, subject)
+	ntf := nats.NewNotifier(js, subject, nats.WithLogger(zaptest.NewLogger(t)))
+
+	_, err = ntf.AddStream(&natsgo.StreamConfig{
+		Name:    subject,
+		Storage: natsgo.MemoryStorage,
+	})
+	assert.NoError(t, err, "creating JetStream stream")
 
 	// Send create
 	dir := &apiv1.Directory{
@@ -187,4 +216,61 @@ func TestNotifyCreateFailsOnBadConnection(t *testing.T) {
 	// Send create
 	err = ntf.NotifyCreate(context.Background(), dir)
 	assert.Error(t, err, "notifying create")
+}
+
+func TestAddStream(t *testing.T) {
+	t.Parallel()
+
+	subject := t.Name()
+
+	conn, err := natsgo.Connect(natss.ClientURL())
+	assert.NoError(t, err, "connecting to nats server")
+
+	js, err := conn.JetStream()
+	assert.NoError(t, err, "creating JetStream connection")
+
+	natsutils.WaitConnected(t, conn)
+
+	ntf := nats.NewNotifier(js, subject, nats.WithLogger(zaptest.NewLogger(t)))
+
+	// Add new stream
+	streamConfig := &natsgo.StreamConfig{
+		Name:    "test",
+		Storage: natsgo.MemoryStorage,
+	}
+	stream, err := ntf.AddStream(streamConfig)
+	assert.NoError(t, err, "expected no error")
+	assert.NotNil(t, stream, "expected stream to not be nil")
+	assert.Equal(t, "test", stream.Config.Name, "created stream name doesn't match request")
+	assert.Contains(t, stream.Config.Subjects, "TestAddStream.>", "expected subject to be added")
+
+	// The provided Stream Config subjects are updated before adding the stream,
+	// so we can check if the subject was added when it actually creates the stream.
+	assert.Contains(t, streamConfig.Subjects, "TestAddStream.>", "expected subject to be added")
+
+	// Use existing stream
+	streamConfig = &natsgo.StreamConfig{
+		Name:    "test",
+		Storage: natsgo.MemoryStorage,
+	}
+	stream, err = ntf.AddStream(streamConfig)
+	assert.NoError(t, err, "expected no error")
+	assert.NotNil(t, stream, "expected stream to not be nil")
+	assert.Equal(t, "test", stream.Config.Name, "created stream name doesn't match request")
+	assert.Contains(t, stream.Config.Subjects, "TestAddStream.>", "expected subject to be added")
+
+	// The provided Stream Config subjects are updated before adding the stream,
+	// so we can check if the subject was added when it actually creates the stream.
+	// In this case we expect it to discover an existing stream and not add the stream,
+	// so the original streamConfig subjects should not contain the injected subject.
+	assert.NotContains(t, streamConfig.Subjects, "TestAddStream.>", "expected subject to not be added")
+
+	// Test StreamInfo failing for something other than Stream not found.
+	streamConfig = &natsgo.StreamConfig{
+		Name:    "bad.stream", // (.) and ( ) are not valid stream names
+		Storage: natsgo.MemoryStorage,
+	}
+	stream, err = ntf.AddStream(streamConfig)
+	assert.Error(t, err, "expected error to be returned for bad name")
+	assert.Nil(t, stream, "expected stream to be nil")
 }

--- a/notifier/nats/utils/testutils.go
+++ b/notifier/nats/utils/testutils.go
@@ -57,7 +57,7 @@ func StartNatsServer(streamSubjects ...string) (*natssrv.Server, error) {
 
 		_, err = js.AddStream(&natsgo.StreamConfig{
 			Name:     streamSubjects[0],
-			Subjects: streamSubjects,
+			Subjects: []string{streamSubjects[0] + ".>"},
 			Storage:  natsgo.MemoryStorage,
 		})
 		if err != nil {

--- a/notifier/nats/utils/utils.go
+++ b/notifier/nats/utils/utils.go
@@ -12,12 +12,19 @@ import (
 	apiv1 "github.com/infratographer/fertilesoil/api/v1"
 )
 
+// RegisterNATSArgs adds nats flags to the provided FlagSet and binds them to Viper.
 func RegisterNATSArgs(v *viper.Viper, flags *pflag.FlagSet) {
 	flags.String("nats-url", "", "NATS URL")
 	viperx.MustBindFlag(v, "nats.url", flags.Lookup("nats-url"))
 
 	flags.String("nats-subject-prefix", "infratographer.events", "NATS subject prefix")
 	viperx.MustBindFlag(v, "nats.subject_prefix", flags.Lookup("nats-subject-prefix"))
+
+	flags.String("nats-stream-name", "fertilesoil", "NATS stream name to create if it doesn't already exist")
+	viperx.MustBindFlag(v, "nats.stream_name", flags.Lookup("nats-stream-name"))
+
+	flags.String("nats-stream-storage", "file", "NATS new stream storage type (memory or file)")
+	viperx.MustBindFlag(v, "nats.stream_storage", flags.Lookup("nats-stream-storage"))
 
 	flags.String("nats-nkey", "", "path to nkey file")
 	viperx.MustBindFlag(v, "nats.nkey", flags.Lookup("nats-nkey"))

--- a/tests/integration/app_test.go
+++ b/tests/integration/app_test.go
@@ -74,7 +74,7 @@ func TestAppReconcileAndWatch(t *testing.T) {
 	// Set up test application
 	appstore := setupAppStorage(t)
 
-	watcher, err := clientv1nats.NewSubscriber(clientconn, subject)
+	watcher, err := clientv1nats.NewSubscriber(clientconn, subject+".*")
 	assert.NoError(t, err, "error creating nats subscriber")
 
 	appctrl, apptester := setupTestApp(t, rd.Directory.Id, cli, watcher, appstore)
@@ -207,7 +207,7 @@ func TestAppWatchWithoutClient(t *testing.T) {
 	// Set up test application
 	appstore := setupAppStorage(t)
 
-	watcher, err := clientv1nats.NewSubscriber(clientconn, subject)
+	watcher, err := clientv1nats.NewSubscriber(clientconn, subject+".*")
 	assert.NoError(t, err, "error creating nats subscriber")
 
 	fullrec, err := appv1.NewSeeder(rd.Directory.Id, cli, appstore)


### PR DESCRIPTION
This updates to be more in line with lb-api nats init process.

If `--nats-stream-name` is provided, check if the stream exists.
If it already exists, do nothing, otherwise create it.

Additionally `--nats-stream-storage` may be provided which may be set to
either `file` (default) or `memory`.